### PR TITLE
Compound: Fix trending query fallback to use GitHub stars

### DIFF
--- a/scripts/compound/prd.json
+++ b/scripts/compound/prd.json
@@ -42,8 +42,8 @@
         "Log LIMIT value (should be 6 tools) to notes"
       ],
       "priority": 3,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Current query in web/src/lib/queries/tools.ts lines 78-104:\n1. Primary query: WHERE isActive=true AND validationStatus IN ['passed','skipped'] AND trendingScore > 0, ORDER BY trendingScore DESC, LIMIT=limit (default 10)\n2. Fallback query (line 91-100): Same WHERE except NO trendingScore filter, ORDER BY compositeScore DESC, LIMIT=limit\n3. Limit is parameterized (default 10), README API uses limit=6\n4. Uses Prisma ORM with prisma.tool.findMany()\n5. Includes category relation"
     },
     {
       "id": "T-004",

--- a/scripts/compound/prd.json
+++ b/scripts/compound/prd.json
@@ -56,8 +56,8 @@
         "No schema changes required (verify only)"
       ],
       "priority": 4,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "CONFIRMED: Schema file at web/prisma/schema.prisma. Table name is 'tools' (line 72), field is 'stars' (line 93) with type Int @default(0). Note: The field is named 'stars' NOT 'github_stars' as mentioned in acceptance criteria. No schema changes required."
     },
     {
       "id": "T-005",

--- a/scripts/compound/prd.json
+++ b/scripts/compound/prd.json
@@ -70,8 +70,8 @@
         "Run `npm run typecheck` - exits with code 0 (if TypeScript project)"
       ],
       "priority": 5,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "ALREADY EXISTS: Empty detection logic already present at line 91 in web/src/lib/queries/tools.ts (if tools.length === 0). No changes needed."
     },
     {
       "id": "T-006",
@@ -84,8 +84,8 @@
         "Add comment explaining fallback query purpose"
       ],
       "priority": 6,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "COMPLETED: Changed orderBy from compositeScore to stars in fallback query at line 99. Updated comment to reflect new behavior. Limit already matches trending query (parameterized)."
     },
     {
       "id": "T-007",
@@ -98,8 +98,8 @@
         "Run `npm run typecheck` - exits with code 0 (if TypeScript project)"
       ],
       "priority": 7,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "ALREADY CORRECT: Both queries assign to same 'tools' variable (lines 79 and 92). Same return statement at line 103. Data structure identical (both include category relation). No frontend changes needed."
     },
     {
       "id": "T-008",
@@ -112,8 +112,8 @@
         "Code compiles without errors"
       ],
       "priority": 8,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "COMPLETED: Added console.log statements at lines 92 and 101. Logs indicate fallback activation and number of tools returned."
     },
     {
       "id": "T-009",

--- a/scripts/compound/progress.txt
+++ b/scripts/compound/progress.txt
@@ -8,6 +8,7 @@ Started: Sun Feb  1 00:08:56 MST 2026
 - GitHub stars stored in `stars` field (not github_stars) in Tool model
 - API endpoints follow pattern: web/src/app/api/v1/{resource}/{action}/route.ts
 - Current fallback uses compositeScore instead of stars (PRD requires stars)
+- Quality checks: `cd web && npm run build` (lint not configured)
 
 ---
 
@@ -59,4 +60,19 @@ Started: Sun Feb  1 00:08:56 MST 2026
 - **Learnings for future iterations:**
   - Field is named 'stars' NOT 'github_stars'
   - Ready to proceed with implementation - all prerequisites met
+---
+
+## 2026-02-01 00:16 - T-005 through T-008
+- Implemented core functionality changes in web/src/lib/queries/tools.ts
+- Changes made:
+  1. T-005: Empty detection already present (line 91)
+  2. T-006: Changed orderBy from `compositeScore: 'desc'` to `stars: 'desc'` (line 99)
+  3. T-007: Confirmed both queries return to same variable (no changes needed)
+  4. T-008: Added console.log statements for fallback activation tracking
+- Updated comment on line 91 to reflect new behavior: "Fallback to top starred tools"
+- Build verification: `cd web && npm run build` - ✓ Compiled successfully
+- **Learnings for future iterations:**
+  - Single line change was the core fix (compositeScore → stars)
+  - Existing architecture was well-designed - minimal changes needed
+  - Logging added for debugging/monitoring fallback activation
 ---

--- a/scripts/compound/progress.txt
+++ b/scripts/compound/progress.txt
@@ -50,3 +50,13 @@ Started: Sun Feb  1 00:08:56 MST 2026
   - Empty detection already exists (line 91: if tools.length === 0)
   - Only need to change orderBy from compositeScore to stars in fallback
 ---
+
+## 2026-02-01 00:15 - T-004
+- Verified database schema in web/prisma/schema.prisma
+- Confirmed 'tools' table (line 72) has 'stars' field (line 93)
+- Field type: Int @default(0)
+- No schema changes required
+- **Learnings for future iterations:**
+  - Field is named 'stars' NOT 'github_stars'
+  - Ready to proceed with implementation - all prerequisites met
+---

--- a/scripts/compound/progress.txt
+++ b/scripts/compound/progress.txt
@@ -35,3 +35,18 @@ Started: Sun Feb  1 00:08:56 MST 2026
   - The main task is to fix the fallback in getTrendingTools() to use stars instead of compositeScore
   - No need to add trending section to homepage - just fix the fallback logic
 ---
+
+## 2026-02-01 00:14 - T-003
+- Documented current query logic from web/src/lib/queries/tools.ts
+- Primary query (lines 79-88):
+  - WHERE: isActive=true, validationStatus IN ['passed','skipped'], trendingScore > 0
+  - ORDER BY: trendingScore DESC
+  - LIMIT: parameterized (default 10, README API uses 6)
+- Fallback query (lines 91-100):
+  - WHERE: same as primary but NO trendingScore filter
+  - ORDER BY: compositeScore DESC (THIS NEEDS TO CHANGE TO stars DESC)
+  - LIMIT: same as primary
+- **Learnings for future iterations:**
+  - Empty detection already exists (line 91: if tools.length === 0)
+  - Only need to change orderBy from compositeScore to stars in fallback
+---

--- a/web/src/lib/queries/tools.ts
+++ b/web/src/lib/queries/tools.ts
@@ -87,17 +87,19 @@ export async function getTrendingTools(limit = 10): Promise<Tool[]> {
     take: limit,
   })
 
-  // Fallback to top-scoring tools if no trending
+  // Fallback to top starred tools if no trending data available
   if (tools.length === 0) {
+    console.log('[getTrendingTools] No trending tools found, falling back to top starred tools')
     tools = await prisma.tool.findMany({
       where: {
         isActive: true,
         validationStatus: { in: ['passed', 'skipped'] },
       },
       include: { category: true },
-      orderBy: { compositeScore: 'desc' },
+      orderBy: { stars: 'desc' },
       take: limit,
     })
+    console.log(`[getTrendingTools] Fallback query returned ${tools.length} tools`)
   }
 
   return tools as unknown as Tool[]


### PR DESCRIPTION
## Summary
- Changes fallback ordering from compositeScore to stars
- Adds console logging when fallback activates
- Ensures homepage shows top-starred tools when no trending data exists

## Test plan
- [ ] Verify homepage loads tools when no trendingScore > 0
- [ ] Check console logs show fallback activation

🤖 Generated with [Claude Code](https://claude.com/claude-code)