### PR TITLE
Add WF13 risk-enrichment catch-up

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,0 +1,365 @@
+# Skill of Skills - Pipeline Architecture
+
+## Current Pipeline (v3.3)
+
+```mermaid
+flowchart TB
+    subgraph "Multi-Platform Discovery (Every 3h)"
+        direction TB
+        A["🔍 GitHub Collector<br/>Scans for skills across 5 platforms"]
+        B[("📥 discovery_queue<br/>Pending repos + platform tag")]
+        C["🔎 Tool Validator<br/>Platform detection, risk, categorization"]
+        R["🛡️ AI Risk Assessment<br/>Claude Haiku analyzes risk"]
+        Q["🧪 Quality Scoring<br/>12 structural signals (max 195pts)"]
+        E["🤖 AI Categorize<br/>9 skill types + platform detection"]
+        D[("🗄️ tools table<br/>+ tool_platforms junction")]
+        F["📢 Discord Notify<br/>New tool alert"]
+    end
+
+    subgraph "Daily Metadata Refresh (3AM UTC)"
+        direction TB
+        M1["⭐ Fetch Stars & Metadata"]
+        M2["📦 Fetch Releases"]
+        M3["🔄 Update Maintenance Status"]
+        M4["❌ 3-Strike Deactivation"]
+    end
+
+    subgraph "Publishing (Every 3h)"
+        G["📝 README Regeneration<br/>Via web API endpoint"]
+        H["📤 GitHub Push<br/>Updates repository"]
+        I["🌐 Web Directory<br/>skills.911fund.io"]
+    end
+
+    A -->|"discovers"| B
+    B -->|"every 3h"| C
+    C -->|"relevance gate"| R
+    R --> Q
+    Q -->|"inserts"| D
+    C -->|"inline"| E
+    E -->|"updates category + platforms"| D
+    C -->|"triggers"| F
+
+    D -->|"daily 3AM"| M1
+    M1 --> M2
+    M2 --> M3
+    M3 -->|"3 consecutive errors"| M4
+
+    M3 -->|"triggers"| G
+    G -->|"pushes"| H
+    H -->|"reflects"| I
+
+    style A fill:#4CAF50
+    style C fill:#2196F3
+    style R fill:#FF9800
+    style Q fill:#E91E63
+    style E fill:#9C27B0
+    style M1 fill:#00BCD4
+    style G fill:#607D8B
+```
+
+## Viral Discovery Pipeline (v3.3)
+
+Beyond the static GitHub collector, the system now has 6 additional discovery sources feeding the same `discovery_queue` -> validator pipeline:
+
+```mermaid
+flowchart LR
+    subgraph "Discovery Sources"
+        S1["GitHub Trending<br/>daily"]
+        S2["Social Discovery<br/>HN/Reddit/X, every 6h"]
+        S3["Awesome-List Diffing<br/>weekly"]
+        S4["Ecosystem Graph<br/>forks/deps/backlinks, weekly"]
+        S5["Adaptive Queries<br/>LLM-generated, biweekly"]
+        S0["Static Queries<br/>19 queries, every 3h"]
+    end
+
+    subgraph "Validation"
+        Q[("discovery_queue")]
+        V["Adaptive Gate<br/>Tier 1: markers/vendors<br/>Tier 2: AI triage"]
+    end
+
+    subgraph "Scoring"
+        QS["Quality Scoring<br/>12 signals, max 200pts"]
+        TS["Trending Score<br/>40% velocity + 30% social + 30% recency"]
+        CS["Composite Score<br/>55% quality + 15% popularity<br/>+ 15% recency + 15% momentum"]
+    end
+
+    S0 --> Q
+    S1 --> Q
+    S2 --> Q
+    S3 --> Q
+    S4 --> Q
+    S5 --> Q
+    Q --> V
+    V -->|"admitted"| QS
+    QS --> TS
+    TS --> CS
+
+    style S1 fill:#FF5722
+    style S2 fill:#2196F3
+    style S3 fill:#4CAF50
+    style S4 fill:#9C27B0
+    style S5 fill:#FF9800
+    style V fill:#E91E63
+```
+
+### Discovery API Endpoints
+
+| Endpoint | Schedule | Purpose |
+|----------|----------|---------|
+| `POST /api/v1/discover/pipeline` | Every 6h (n8n) | Full pipeline orchestrator — calls all steps in sequence |
+| `POST /api/v1/discover/trending` | Daily | Scrape GitHub Trending, filter by AI-coding keywords |
+| `POST /api/v1/discover/social` | Every 6h | Extract GitHub URLs from HN/Reddit/X posts |
+| `POST /api/v1/discover/awesome-lists` | Weekly | Diff 10 curated awesome-lists for newly added repos |
+| `POST /api/v1/discover/ecosystem` | Weekly | Discover via active forks, dependency graphs, README backlinks |
+| `POST /api/v1/discover/adaptive-queries` | Biweekly | LLM generates new search queries; run and prune lifecycle |
+| `POST /api/v1/discover/validate-candidate` | After discovery | Two-tier relevance gate (markers + AI triage) |
+| `POST /api/v1/batch/trending-recalc` | Daily | Recalculate trending scores + record metrics_history |
+
+### Trending Score Formula
+
+```
+trending_score = 0.4 * velocity_norm + 0.3 * social_norm + 0.3 * recency_norm
+
+where:
+  velocity_norm = min(1, stars_per_day / 100)
+  social_norm   = min(1, (x_mentions + reddit_mentions) / 50)
+  recency_norm  = recent_activity_score / 15
+```
+
+### Composite Score Formula (v3.3)
+
+```
+composite = 0.55 * quality + 0.15 * popularity + 0.15 * recency + 0.15 * momentum
+
+where:
+  quality    = quality_score / 200
+  popularity = min(1, stars / 10000)
+  recency    = recent_activity / 15
+  momentum   = min(1, star_velocity / 100)
+```
+
+## Active Workflows
+
+| Workflow | Schedule | Purpose |
+|----------|----------|---------|
+| **01 - GitHub Multi-Type Collector** | Every 3h | Scan GitHub for new skills across all platforms |
+| **05 - Tool Validator** | Every 3h / Webhook | Validate, risk-assess, quality-score, categorize, insert |
+| **07 - README Generator** | Every 3h | Regenerate README via web app API |
+| **08 - Discord New Tool Notifier** | On new tool (webhook) | Send Discord alert for new discoveries |
+| **09 - Discord Weekly Digest** | Weekly Monday 9AM UTC | Weekly summary to Discord |
+| **13 - Daily Metadata Refresh** | Daily 3AM UTC (cron) | Star counts, releases, maintenance status, and risk-enrichment catch-up |
+
+## Disabled Workflows
+
+| Workflow | Reason |
+|----------|--------|
+| 07 - README Generator (5 old copies) | Replaced by active v3 copy |
+| 07 - README Generator (Minimal) | Superseded |
+| 10 - Unknown Tool Alert | No longer needed with improved categorization |
+| 12 - Trending Score Recalculation | Removed in v1.1.0 |
+| Job Deduplication Helper | Internal sub-workflow |
+
+---
+
+## 01 - GitHub Multi-Type Collector
+
+Searches GitHub API for AI coding skills across multiple platforms.
+
+**Queries loaded from** `config/discovery-queries.json`:
+- **Claude Code**: `SKILL.md`, `.claude`, `claude-plugin`, `mcp.json`, `topic:claude-code`
+- **Cursor**: `.cursorrules`, `topic:cursor-rules`, `awesome-cursorrules`
+- **Codex**: `AGENTS.md openai`, `topic:codex-agent`
+- **Windsurf**: `.windsurfrules`, `topic:windsurf-rules`
+- **Cline**: `.clinerules`, `topic:cline`
+- **Generic**: `awesome-ai-coding-tools`, `topic:ai-coding-assistant`
+
+Adds discoveries to `discovery_queue` with `platform` field set.
+
+## 05 - Tool Validator
+
+Validates pending discoveries and inserts them into the tools table.
+
+**Flow:**
+1. Get pending items from `discovery_queue` (LIMIT 10)
+2. Parse URL -> Fetch repo info -> Fetch file contents
+3. **Platform Detection**: Check for SKILL.md, .cursorrules, AGENTS.md, .windsurfrules, .clinerules
+4. **Relevance Gate**: Must have platform markers OR be in curated list OR manual submission
+5. **AI Risk Assessment**: Claude Haiku analyzes SKILL.md + file list for risk signals
+6. **Quality Scoring**: 12 structural signals (gotchas, folders, verification, examples, etc.)
+7. **Insert Tool**: `ON CONFLICT slug DO UPDATE` (metadata refreshes on re-discovery)
+8. **Populate tool_platforms**: Insert detected platforms into junction table
+9. **AI Categorize**: Claude Haiku classifies into one of 9 skill types + detects platforms
+10. **Discord Notify**: Alert for new tools
+
+**Relevance Gate (v3):**
+Repos must pass at least one:
+- Has platform marker file (SKILL.md, .cursorrules, AGENTS.md, etc.)
+- Is in a curated "awesome-*" list
+- Was explicitly submitted via submission form
+- Generic repos without markers are rejected (prevents PyTorch, etc.)
+
+## Quality Scoring Engine
+
+Scores each tool on 12 structural signals (max 200 points):
+
+| Signal | Points | Detection |
+|--------|--------|-----------|
+| Gotchas/Edge Cases section | +40 | Heading pattern match in README/SKILL.md |
+| Folder structure (progressive disclosure) | +30 | >=2 of: examples/, verification/, scripts/, etc. |
+| Specific trigger description | +20 | YAML frontmatter description >40 chars with trigger words |
+| Verification/safety signals | +20 | /careful, /freeze, sandbox, hooks, assertions |
+| Code examples | +15 | >=3 fenced code blocks |
+| Composability | +15 | References sub-agents, chains, pipelines |
+| Recent activity | +15 | Commits within 60 days |
+| Real usage evidence | +10 | Issues/PRs with usage discussion |
+| Single responsibility | +10 | SKILL.md <300 lines |
+| Config/persistence | +10 | config.json, data/ folder |
+| Installation instructions | +5 | Contains install/setup/getting started |
+| Multi-platform support | +5 | Detected on >=2 platforms |
+
+**Quality Tiers:**
+- **Curated** (>=120): Surface prominently, badge on card
+- **Promising** (80-119): Good default listing
+- **Experimental** (40-79): Listed but de-emphasized
+- **Review Required** (<40): Needs review
+
+**Composite Score Formula (v3.3):**
+```
+composite = 0.55 * quality + 0.15 * popularity + 0.15 * recency + 0.15 * momentum
+```
+See "Viral Discovery Pipeline" section above for full formula details.
+
+## 13 - Daily Metadata Refresh
+
+Refreshes metadata for all active tools daily at 3AM UTC.
+
+**Flow:**
+1. Get active tools (LIMIT 150, ordered by `stars_verified_at ASC NULLS FIRST`)
+2. Split into batches of 10
+3. For each tool: Fetch repo metadata -> Check for API errors
+4. **Error path**: Increment error count -> 3 strikes -> Deactivate + Discord alert
+5. **Success path**: Extract metadata -> Fetch releases -> Count releases
+6. Update: stars, stars_previous, open_issues_count, release_count, latest_release_at
+7. Reset refresh_error_count on success
+8. Wait 500ms between metadata batches (rate limiting)
+9. Run batch quality-score catch-up for still-unscored tools
+10. Run batch reassess-risk catch-up for tools still marked `enrichment-pending` or heuristic fallback
+11. Retry uncategorized tools via `categorize-single`
+12. Trigger README regeneration after catch-up passes complete
+
+## 08 - Discord New Tool Notifier
+
+- Triggered by webhook from Tool Validator
+- Sends embed with tool name, description, stars, category, platforms
+- Batched at 2s intervals to avoid rate limits
+
+## 09 - Discord Weekly Digest
+
+- Runs weekly Monday 9AM UTC
+- Summarizes new tools discovered in the past week
+
+---
+
+## Skill Types (9 categories)
+
+| # | Category | Slug | Description |
+|---|----------|------|-------------|
+| 1 | Library & API Reference | `library-api-reference` | How to correctly use a library, CLI, or SDK |
+| 2 | Product Verification | `product-verification` | Test/verify code is working |
+| 3 | Data Fetching & Analysis | `data-fetching-analysis` | Connect to data/monitoring stacks |
+| 4 | Business Process Automation | `business-process-automation` | Automate team workflows |
+| 5 | Code Scaffolding & Templates | `code-scaffolding-templates` | Generate boilerplate with conventions |
+| 6 | Code Quality & Review | `code-quality-review` | Enforce standards, adversarial review |
+| 7 | CI/CD & Deployment | `cicd-deployment` | Build, test, deploy pipelines |
+| 8 | Runbooks | `runbooks` | Symptom -> investigation -> report |
+| 9 | Infrastructure Operations | `infrastructure-ops` | Maintenance with guardrails |
+| 99 | Uncategorized | `uncategorized` | Fallback (target: <10%) |
+
+## Supported Platforms
+
+| Platform | Markers | Vendor Org |
+|----------|---------|------------|
+| Claude Code | SKILL.md, .claude/, plugin.json, CLAUDE.md | anthropics |
+| Cursor | .cursorrules, .cursor/ | getcursor |
+| Codex | AGENTS.md | openai |
+| Windsurf | .windsurfrules | codeium |
+| Cline | .clinerules, cline-config | cline-ai |
+| Generic | (no markers) | — |
+
+**Vendor-aware `is_official`**: A tool is official when `repo_owner` matches a known vendor org.
+
+---
+
+## Database Schema (v3)
+
+Key tables:
+- `tools` — Main table with quality columns (`quality_score`, `has_gotchas`, `has_examples`, `has_progressive_disclosure`, `has_scripts`, `has_verification`, `has_config_files`, `readme_length`, `primary_platform`, `vendor`)
+- `tool_platforms` — Many-to-many junction (tool can support multiple platforms)
+- `categories` — 9 skill types + uncategorized
+- `discovery_queue` — Includes `platform` column
+- `archived_tools` — Deactivated tools (recoverable)
+
+Enums: `tool_type` (includes `cursor_rule`, `codex_agent`), `platform`, `risk_level`, `validation_status`
+
+Migration history:
+- `001` — Initial schema
+- `002-v2-enhancements` — Star verification, maintenance signals, category confidence
+- `003-platform-revamp` — Multi-platform, quality scoring, 9 categories, vendor support
+- `004-viral-discovery` — Discovery source enums, velocity columns, awesome_list_snapshots, adaptive_queries tables
+
+---
+
+## Webhook Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/webhook/categorize-single` | POST | AI categorization (9 types + platforms) |
+| `/api/v1/readme/regenerate` | GET/POST | README generation (GET=preview, POST=push to GitHub) |
+| `/api/v1/tools` | GET | Public tools API (supports `platform` filter) |
+| `/api/v1/categories` | GET | Categories API |
+| `/api/v1/stats` | GET | Platform statistics |
+| `/api/v1/webhook/score-single` | POST | Single-tool quality + trending scoring |
+| `/api/v1/webhook/reassess-risk` | POST | Single-tool risk + SBOM enrichment |
+| `/api/v1/batch/quality-score` | POST | Batch quality scoring |
+| `/api/v1/batch/reassess-risk` | POST | Batch risk + SBOM enrichment catch-up |
+| `/api/v1/batch/trending-recalc` | POST | Batch trending score recalculation |
+| `/api/v1/discover/pipeline` | POST | Full viral discovery pipeline orchestrator |
+| `/api/v1/discover/trending` | POST | GitHub Trending scraper |
+| `/api/v1/discover/social` | POST | Social discovery (HN/Reddit/X) |
+| `/api/v1/discover/awesome-lists` | POST | Awesome-list diffing |
+| `/api/v1/discover/ecosystem` | POST | Ecosystem graph discovery |
+| `/api/v1/discover/adaptive-queries` | POST/GET | Adaptive query lifecycle |
+| `/api/v1/discover/validate-candidate` | POST | Two-tier relevance gate |
+
+---
+
+## Infrastructure
+
+- **Web app**: Next.js 14 (Docker, port 3001)
+- **Database**: PostgreSQL 15 (Docker, port 5433)
+- **Automation**: n8n (Docker, port 5679)
+- **Deployment**: Docker Compose on AWS (`/home/ubuntu/skill-of-skills-clean/docker/`)
+- **Source**: `/home/ubuntu/skill-of-skills-clean/` (AWS)
+- **Public repo**: `github.com/the911fund/skill-of-skills` (README auto-pushed)
+
+---
+
+## Rollback Procedure
+
+If v3 migration needs to be rolled back:
+
+```bash
+# Restore pre-v3 database backup
+sudo docker exec -i skill-of-skills-db pg_restore -U skillmaster -d skill_of_skills --clean --if-exists < /home/ubuntu/skill-of-skills-clean/database/backups/pre-v3-backup-20260321.dump
+
+# Revert code to pre-v3 state
+git log --oneline  # find pre-v3 commit
+git checkout <commit> -- web/ config/ database/
+
+# Rebuild web container
+cd /home/ubuntu/skill-of-skills-clean/docker && sudo docker compose build web && sudo docker compose up -d web
+```
+
+---
+
+*Last updated: 2026-04-05 (v3.3 — viral discovery pipeline)*

--- a/n8n-workflows/13-daily-metadata-refresh.json
+++ b/n8n-workflows/13-daily-metadata-refresh.json
@@ -1,0 +1,488 @@
+{
+  "name": "13 - Daily Metadata Refresh",
+  "nodes": [
+    {
+      "id": "schedule-trigger",
+      "name": "Daily 3AM UTC",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [200, 300],
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 3 * * *"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "get-active-tools",
+      "name": "Get Active Tools",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [400, 300],
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT id, repo_owner, repo_name, stars, refresh_error_count FROM tools WHERE is_active = true ORDER BY stars_verified_at ASC NULLS FIRST LIMIT 150",
+        "options": {}
+      },
+      "credentials": {
+        "postgres": {
+          "id": "2QEo1AX3zIOJcmsK",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "id": "split-batches",
+      "name": "Split In Batches",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [600, 300],
+      "parameters": {
+        "batchSize": 10,
+        "options": {}
+      }
+    },
+    {
+      "id": "build-url",
+      "name": "Build GitHub URL",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [800, 300],
+      "parameters": {
+        "mode": "runOnceForEachItem",
+        "jsCode": "const item = $json;\nreturn {json: {\n  ...item,\n  github_api_url: `https://api.github.com/repos/${item.repo_owner}/${item.repo_name}`,\n  releases_url: `https://api.github.com/repos/${item.repo_owner}/${item.repo_name}/releases?per_page=100`\n}};"
+      }
+    },
+    {
+      "id": "fetch-repo",
+      "name": "Fetch Repo Metadata",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1000, 300],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $json.github_api_url }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "Accept", "value": "application/vnd.github.v3+json"}
+          ]
+        },
+        "options": {}
+      },
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "KLKAH2UEzvuoHbs4",
+          "name": "Header Auth account"
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-error",
+      "name": "API Error?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1200, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "leftValue": "",
+            "caseSensitive": true,
+            "typeValidation": "strict"
+          },
+          "combinator": "or",
+          "conditions": [
+            {
+              "id": "err1",
+              "operator": {
+                "type": "number",
+                "operation": "gte"
+              },
+              "leftValue": "={{ $json.statusCode || 200 }}",
+              "rightValue": 400
+            },
+            {
+              "id": "err2",
+              "operator": {
+                "type": "string",
+                "operation": "exists",
+                "singleValue": true
+              },
+              "leftValue": "={{ $json.message }}"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "increment-error",
+      "name": "Increment Error Count",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1400, 200],
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE tools SET refresh_error_count = refresh_error_count + 1, updated_at = NOW() WHERE id = '{{ $('Build GitHub URL').item.json.id }}' RETURNING id, refresh_error_count",
+        "options": {}
+      },
+      "credentials": {
+        "postgres": {
+          "id": "2QEo1AX3zIOJcmsK",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "id": "check-deactivate",
+      "name": "3 Strikes?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1600, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "leftValue": "",
+            "caseSensitive": true,
+            "typeValidation": "strict"
+          },
+          "combinator": "and",
+          "conditions": [
+            {
+              "id": "strike3",
+              "operator": {
+                "type": "number",
+                "operation": "gte"
+              },
+              "leftValue": "={{ $json.refresh_error_count }}",
+              "rightValue": 3
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "deactivate-tool",
+      "name": "Deactivate Tool",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1800, 150],
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE tools SET is_active = false, updated_at = NOW() WHERE id = '{{ $json.id }}' RETURNING id, (SELECT name FROM tools WHERE id = '{{ $json.id }}') as tool_name",
+        "options": {}
+      },
+      "credentials": {
+        "postgres": {
+          "id": "2QEo1AX3zIOJcmsK",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "id": "discord-deactivate",
+      "name": "Discord: Deactivated",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2000, 150],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.DISCORD_WEBHOOK_URL }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({embeds:[{title:'🗑️ Tool Deactivated (3 consecutive errors)',description:'Tool ID: ' + $json.id,color:16711680,timestamp:new Date().toISOString()}]}) }}",
+        "options": {}
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "extract-metadata",
+      "name": "Extract Metadata",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1400, 400],
+      "parameters": {
+        "mode": "runOnceForEachItem",
+        "jsCode": "const repo = $json;\nconst prev = $('Build GitHub URL').item.json;\n\nconst newStars = repo.stargazers_count || 0;\nconst oldStars = prev.stars || 0;\nconst delta = oldStars > 0 ? Math.abs(newStars - oldStars) / oldStars : 0;\n\nreturn {json: {\n  id: prev.id,\n  repo_owner: prev.repo_owner,\n  repo_name: prev.repo_name,\n  new_stars: newStars,\n  old_stars: oldStars,\n  star_delta_pct: Math.round(delta * 100),\n  last_commit_at: repo.pushed_at || null,\n  open_issues_count: repo.open_issues_count || 0,\n  releases_url: prev.releases_url\n}};"
+      }
+    },
+    {
+      "id": "fetch-releases",
+      "name": "Fetch Releases",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1600, 400],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $json.releases_url }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "Accept", "value": "application/vnd.github.v3+json"}
+          ]
+        },
+        "options": {}
+      },
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "KLKAH2UEzvuoHbs4",
+          "name": "Header Auth account"
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "count-releases",
+      "name": "Count Releases",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1800, 400],
+      "parameters": {
+        "mode": "runOnceForEachItem",
+        "jsCode": "const releases = $json;\nconst prev = $('Extract Metadata').item.json;\n\n// The HTTP Request node auto-splits arrays, so we may get a single release object\n// or the previous item's data if releases is empty/error\nlet releaseCount = 0;\nlet latestReleaseAt = null;\n\ntry {\n  // If we got back an array (from the raw response)\n  if (Array.isArray(releases)) {\n    releaseCount = releases.length;\n    if (releases.length > 0) {\n      latestReleaseAt = releases[0].published_at || releases[0].created_at;\n    }\n  } else if (releases && releases.tag_name) {\n    // Single release object (auto-split)\n    // In this case we need to count from input items\n    const items = $input.all();\n    releaseCount = items.filter(i => i.json.tag_name).length;\n    if (items.length > 0) {\n      latestReleaseAt = items[0].json.published_at || items[0].json.created_at;\n    }\n  }\n} catch (e) {\n  // No releases available\n}\n\nreturn {json: {\n  ...prev,\n  release_count: releaseCount,\n  latest_release_at: latestReleaseAt\n}};"
+      }
+    },
+    {
+      "id": "update-tool",
+      "name": "Update Tool Metadata",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [2000, 400],
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE tools SET stars = {{ $json.new_stars }}, stars_previous = {{ $json.old_stars }}, stars_verified_at = NOW(), last_commit_at = {{ $json.last_commit_at ? \"'\" + $json.last_commit_at + \"'\" : \"last_commit_at\" }}, open_issues_count = {{ $json.open_issues_count }}, release_count = {{ $json.release_count || 0 }}, latest_release_at = {{ $json.latest_release_at ? \"'\" + $json.latest_release_at + \"'\" : \"latest_release_at\" }}, refresh_error_count = 0, updated_at = NOW() WHERE id = '{{ $json.id }}'",
+        "options": {}
+      },
+      "credentials": {
+        "postgres": {
+          "id": "2QEo1AX3zIOJcmsK",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "id": "wait-rate-limit",
+      "name": "Wait 500ms",
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [2200, 300],
+      "parameters": {
+        "amount": 0.5,
+        "unit": "seconds"
+      },
+      "webhookId": "wait-rate-limit-wh"
+    },
+    {
+      "id": "score-unscored",
+      "name": "Score Unscored Tools",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2400, 300],
+      "parameters": {
+        "method": "POST",
+        "url": "http://skill-of-skills-web:3000/api/v1/batch/quality-score",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\"onlyUnscored\": true, \"limit\": 100}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "reassess-pending-risk",
+      "name": "Enrichment Catch-up",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2500, 300],
+      "parameters": {
+        "method": "POST",
+        "url": "http://skill-of-skills-web:3000/api/v1/batch/reassess-risk",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "x-webhook-secret", "value": "={{ $env.WEBHOOK_SECRET }}"}
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\"limit\": 100}",
+        "options": {
+          "timeout": 180000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "trigger-readme",
+      "name": "Trigger README Update",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2600, 300],
+      "parameters": {
+        "method": "POST",
+        "url": "http://skill-of-skills-web:3000/api/v1/readme/regenerate",
+        "options": {}
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "get-uncategorized",
+      "name": "Get Uncategorized",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [2800, 300],
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT t.id FROM tools t JOIN categories c ON t.category_id = c.id WHERE t.is_active = true AND c.slug = 'uncategorized' AND (t.category_confidence IS NULL OR t.updated_at < NOW() - INTERVAL '1 hour') LIMIT 10",
+        "options": {}
+      },
+      "credentials": {
+        "postgres": {
+          "id": "2QEo1AX3zIOJcmsK",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "id": "loop-categorize",
+      "name": "Loop Categorize",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [3000, 300],
+      "parameters": {
+        "batchSize": 1,
+        "options": {}
+      }
+    },
+    {
+      "id": "call-categorize",
+      "name": "Call Categorize Webhook",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3200, 300],
+      "parameters": {
+        "method": "POST",
+        "url": "http://skill-of-skills-web:3000/api/v1/webhook/categorize-single",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {"name": "x-webhook-secret", "value": "={{ $env.WEBHOOK_SECRET }}"}
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"tool_id\": \"{{ $json.id }}\",\n  \"forceRefetch\": true\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "wait-categorize",
+      "name": "Wait 3s",
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [3400, 300],
+      "parameters": {
+        "amount": 3,
+        "unit": "seconds"
+      },
+      "webhookId": "wait-categorize-wh"
+    }
+  ],
+  "connections": {
+    "Daily 3AM UTC": {
+      "main": [[{"node": "Get Active Tools", "type": "main", "index": 0}]]
+    },
+    "Get Active Tools": {
+      "main": [[{"node": "Split In Batches", "type": "main", "index": 0}]]
+    },
+    "Split In Batches": {
+      "main": [
+        [{"node": "Build GitHub URL", "type": "main", "index": 0}],
+        [{"node": "Score Unscored Tools", "type": "main", "index": 0}]
+      ]
+    },
+    "Score Unscored Tools": {
+      "main": [[{"node": "Enrichment Catch-up", "type": "main", "index": 0}]]
+    },
+    "Enrichment Catch-up": {
+      "main": [[{"node": "Trigger README Update", "type": "main", "index": 0}]]
+    },
+    "Trigger README Update": {
+      "main": [[{"node": "Get Uncategorized", "type": "main", "index": 0}]]
+    },
+    "Get Uncategorized": {
+      "main": [[{"node": "Loop Categorize", "type": "main", "index": 0}]]
+    },
+    "Loop Categorize": {
+      "main": [
+        [],
+        [{"node": "Call Categorize Webhook", "type": "main", "index": 0}]
+      ]
+    },
+    "Call Categorize Webhook": {
+      "main": [[{"node": "Wait 3s", "type": "main", "index": 0}]]
+    },
+    "Wait 3s": {
+      "main": [[{"node": "Loop Categorize", "type": "main", "index": 0}]]
+    },
+    "Build GitHub URL": {
+      "main": [[{"node": "Fetch Repo Metadata", "type": "main", "index": 0}]]
+    },
+    "Fetch Repo Metadata": {
+      "main": [[{"node": "API Error?", "type": "main", "index": 0}]]
+    },
+    "API Error?": {
+      "main": [
+        [{"node": "Increment Error Count", "type": "main", "index": 0}],
+        [{"node": "Extract Metadata", "type": "main", "index": 0}]
+      ]
+    },
+    "Increment Error Count": {
+      "main": [[{"node": "3 Strikes?", "type": "main", "index": 0}]]
+    },
+    "3 Strikes?": {
+      "main": [
+        [{"node": "Deactivate Tool", "type": "main", "index": 0}],
+        [{"node": "Wait 500ms", "type": "main", "index": 0}]
+      ]
+    },
+    "Deactivate Tool": {
+      "main": [[{"node": "Discord: Deactivated", "type": "main", "index": 0}]]
+    },
+    "Discord: Deactivated": {
+      "main": [[{"node": "Wait 500ms", "type": "main", "index": 0}]]
+    },
+    "Extract Metadata": {
+      "main": [[{"node": "Fetch Releases", "type": "main", "index": 0}]]
+    },
+    "Fetch Releases": {
+      "main": [[{"node": "Count Releases", "type": "main", "index": 0}]]
+    },
+    "Count Releases": {
+      "main": [[{"node": "Update Tool Metadata", "type": "main", "index": 0}]]
+    },
+    "Update Tool Metadata": {
+      "main": [[{"node": "Wait 500ms", "type": "main", "index": 0}]]
+    },
+    "Wait 500ms": {
+      "main": [[{"node": "Split In Batches", "type": "main", "index": 0}]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary
- add an `Enrichment Catch-up` step to Workflow 13 to call `/api/v1/batch/reassess-risk`
- document the Workflow 13 catch-up pass in `docs/PIPELINE.md`
- keep this PR scoped to the workflow/docs source-of-truth change only

## Verification
- imported WF13 into live n8n
- rebuilt and redeployed the web container so `/api/v1/batch/reassess-risk` is live
- verified live `enrichment-pending` backlog drain: `13 -> 0`

## Notes
- the README regeneration route alignment was left out of this PR because that path is not tracked on `origin/main`
- broader heuristic-fallback reassessment remains out of scope