### PR TITLE
Fix sync workflow failing when N8N_SYNC_WEBHOOK is unset

### DIFF
--- a/.github/workflows/sync-official.yml
+++ b/.github/workflows/sync-official.yml
@@ -28,16 +28,19 @@ jobs:
         run: python3 scripts/validate_sources.py
 
       - name: Check webhook configuration
-        if: ${{ github.event.inputs.dry_run != 'true' }}
+        id: webhook
         env:
           N8N_SYNC_WEBHOOK: ${{ secrets.N8N_SYNC_WEBHOOK }}
         run: |
           if [ -z "$N8N_SYNC_WEBHOOK" ]; then
-            echo "N8N_SYNC_WEBHOOK is not configured. Add it as a repository secret or run workflow_dispatch with dry_run=true." >&2
-            exit 2
+            echo "::notice::N8N_SYNC_WEBHOOK is not configured — skipping sync. Add it as a repository secret to enable posting to n8n."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Sync official/reference sources to n8n
+        if: ${{ steps.webhook.outputs.configured == 'true' || github.event.inputs.dry_run == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           N8N_SYNC_WEBHOOK: ${{ secrets.N8N_SYNC_WEBHOOK }}

--- a/scripts/sync_official_sources.py
+++ b/scripts/sync_official_sources.py
@@ -110,11 +110,11 @@ def source_payload(source: dict, candidates: list[dict]) -> dict:
 
 def main() -> int:
     webhook = os.environ.get("N8N_SYNC_WEBHOOK", "").strip()
-    if not webhook:
+    dry_run = os.environ.get("DRY_RUN", "false").lower() in {"1", "true", "yes"}
+    if not webhook and not dry_run:
         print("error: N8N_SYNC_WEBHOOK is not configured; refusing to POST to an empty URL", file=sys.stderr)
         return 2
     token = os.environ.get("GITHUB_TOKEN", "").strip() or None
-    dry_run = os.environ.get("DRY_RUN", "false").lower() in {"1", "true", "yes"}
 
     sources = parse_sources((ROOT / "sources.yml").read_text())
     errors = validate(sources)


### PR DESCRIPTION
## Problem

The `Sync Official Sources` workflow (`.github/workflows/sync-official.yml`) has been failing on **every scheduled run**. The dashboard shows it twice — once as "Sync Official Plugins" (the workflow's former name, last run `9a1614b`) and once as "Sync Official Sources" (current name, `42bf1bf`) — but it's the same file.

**Root cause:** the `N8N_SYNC_WEBHOOK` repository secret is not configured (the repo has no secrets at all). The `Check webhook configuration` step hard-failed with `exit 2` whenever the secret was missing, so the cron went red every 12 hours. Source validation itself passes cleanly (6 sources, 0 errors).

## Fix

Make a missing webhook a **graceful skip** instead of a hard failure:

- The check step now emits a `::notice::` and sets a `configured` step output instead of `exit 2`.
- The sync step is gated with `if: configured == 'true' || dry_run == 'true'`, so scheduled runs without a webhook validate sources and skip the post — exiting green.
- `scripts/sync_official_sources.py` no longer requires the webhook in dry-run mode, so manual `workflow_dispatch` dry-runs work for testing. A real (non-dry) run with no webhook still refuses (`exit 2`), but the workflow no longer reaches that path on schedule.

Self-healing: if you later add the `N8N_SYNC_WEBHOOK` secret, syncing resumes automatically with no further changes.

## Verification (local)

- `validate_sources.py` → exit 0
- dry-run, no webhook → exit 0 (discovers, does not post)
- real run, no webhook → exit 2 (still refuses; now guarded by the workflow `if`)
- workflow YAML parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)