### PR TITLE
Bump actions/checkout v4 → v5

### DIFF
--- a/.github/workflows/sync-official.yml
+++ b/.github/workflows/sync-official.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate source registry
         run: python3 scripts/validate_sources.py

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Bumps `actions/checkout` from `v4` to `v5` in the two workflows that use it (`sync-official.yml`, `update-readme.yml`).

`v4` runs on Node.js 20, which GitHub deprecates on **June 16, 2026** (Node 20 removed from runners Sept 16, 2026). `v5` runs on Node.js 24. `validate-tool.yml` uses no actions, so no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)