### PR TITLE
Docs: score evidence for handoff artifacts

### DIFF
--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -19,6 +19,8 @@ Keep component scores separate so users and agents can inspect why something ran
 - `safety_score`: permission scope, shell execution, subagents, destructive actions, approval gates.
 - `installability_score`: clear installation/loading steps, supported platforms, dependencies.
 - `popularity_score`: stars/forks/social signals, capped to prevent giant generic repos from dominating.
+- `evidence_score`: machine-checkable proof that the skill's claims, inputs,
+  outputs, and resume state can be verified instead of trusted as prose.
 
 ## Default weighted rank
 
@@ -59,11 +61,14 @@ Positive:
 - examples
 - gotchas/pitfalls
 - verification section
+- evidence/provenance section for generated outputs, handoffs, or derived context
 - linked references/templates/scripts
 - progressive disclosure instead of huge context dumps
 - explicit safety/approval gates
 - install/load instructions
 - exact commands with expected outputs
+- stale/invalidator rules for handoffs, cached context, generated files, or
+  tool catalogs (`stale_if`, source hash changed, branch changed, toolset changed)
 
 Negative:
 
@@ -71,9 +76,35 @@ Negative:
 - no description or trigger language
 - stale with no releases
 - broad system access with no approval gates
+- handoff or memory claims with no source refs, timestamps, commit/worktree state,
+  or re-verification instructions
 - hallucinated/generated README only
 - repo-level record pretending to be a skill-level record
 - clone or validation failed but status says passed
+
+## Evidence and provenance signals
+
+Skills increasingly generate durable artifacts: handoff files, context packs,
+tool catalogs, cached summaries, task plans, audit logs, and merged/fused rule
+sets. Treat these as higher quality when they include a small evidence block that
+lets the next agent or human reviewer verify whether the artifact is still safe
+to act on.
+
+Useful fields to detect and surface:
+
+- source artifact references: file paths, trace ids, session ids, issue/PR refs,
+  or upstream skill ids
+- source digests or commit/worktree state used when the artifact was produced
+- generator identity and version: skill/command name, renderer version, model or
+  agent harness when intentionally disclosed
+- verification commands or read-only smoke checks with expected output
+- omitted-private-context markers without exposing the private content
+- `stale_if` invalidators: source hash changed, branch/commit changed, tool
+  registry changed, skill version changed, compaction policy changed, or
+  referenced file changed after capture
+
+Do not require raw prompts, secrets, full traces, or private file contents. Hashes
+and stable references are enough for ranking and review.
 
 ## Tiers
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -23,6 +23,8 @@ Each validated record should include:
 - validation errors/warnings
 - validation timestamp
 - repository commit SHA used for validation
+- evidence/provenance markers when present (`stale_if`, source refs, source
+  hashes, resume checks, renderer/skill version, omitted-private-context flags)
 
 ## Fail closed
 
@@ -58,6 +60,27 @@ Risk should include exact reasons. Examples:
 - browser/computer-use automation
 - broad filesystem writes
 - lack of explicit human approval gates
+- durable handoff/memory artifacts that are loaded automatically but have no
+  freshness check, source reference, or invalidation rule
+
+## Handoff and generated-context validation
+
+When a skill writes a handoff, summary, cached context file, fused ruleset, or
+tool catalog for a future agent to load, validate the artifact as a boundary, not
+as ordinary documentation.
+
+Prefer records that prove:
+
+- what source state was summarized or transformed
+- which repo/worktree/branch/commit or trace ids were used
+- which command, skill, or renderer produced the artifact
+- which claims were verified against the current workspace versus asserted from
+  conversation memory
+- what private context was intentionally omitted without exposing it
+- when the artifact becomes stale or must be regenerated
+
+If a generated artifact can steer future tool use but has no freshness or source
+evidence, downgrade it or mark it for review even when the prose is polished.
 
 ## n8n workflow validation
 


### PR DESCRIPTION
## Description
Adds evidence/provenance scoring guidance for skills that generate durable handoffs, cached context, fused rules, tool catalogs, or other artifacts a future agent may load.

The goal is to rank these artifacts by verifiability, not just polished prose: source refs, hashes/commit state, renderer or skill version, verification checks, omitted-private-context markers, and stale/invalidator rules.

## Type of Change
- [x] Documentation update
- [x] Workflow improvement

## Checklist
- [x] I have tested these changes locally
- [x] I have updated documentation as needed
- [x] No secrets or credentials are included
- [x] Workflows are sanitized (placeholder credential IDs)

## Tests
- `git diff --check`
- `python3 scripts/validate_sources.py`

## Additional Notes
This is motivated by the current wave of Claude Code handoff/session-continuity skills and agent-memory tools: if a generated handoff can steer the next agent, the directory should reward explicit provenance and freshness evidence and downgrade auto-loaded artifacts with no invalidation story.